### PR TITLE
fix(security): enable method-level security to enforce @PreAuthorize in UserController

### DIFF
--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/JwtAuthorizationFilter.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/JwtAuthorizationFilter.java
@@ -74,6 +74,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             new SimpleGrantedAuthority(roleName)
         );
 
+        System.out.println("Authorities del usuario: " + authorities);
+
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(email, null, authorities);
 
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/SecurityConfig.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -9,6 +10,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true) // Habilitar anotaciones @PreAuthorize y @PostAuthorize
 public class SecurityConfig {
 
     private final JwtAuthorizationFilter jwtAuthorizationFilter;


### PR DESCRIPTION
Este PR se encargo de reparar un bug en la seguridad en UserController ya que al no tener activada la anotación @EnableMethodSecurity(prePostEnabled = true) en SecurityConfig no se estaba respetando las anotaciones @PreAuthorize("hasAnyRole('ADMIN', 'USER')") y @PreAuthorize("hasRole('ADMIN')") en el controlador y por lo tanto no funcionaba como debería de acuerdo a sus rol las acciones.