### PR TITLE
feat(obra): Implement CRUD operations for obra  module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,13 @@
             <scope>runtime</scope> <!-- This module allows jjwt to work with Jackson for JSON processing. Alternatively, you could use jjwt-gson if you prefer Gson over Jackson. -->
         </dependency>
 
+		<!-- MapStruct -->
+		<dependency>
+    		<groupId>org.mapstruct</groupId>
+    		<artifactId>mapstruct</artifactId>
+    		<version>1.5.5.Final</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -122,6 +129,16 @@
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
 						</path>
+						<path>
+                        	<groupId>org.mapstruct</groupId>
+                        	<artifactId>mapstruct-processor</artifactId>
+                        	<version>1.5.5.Final</version>
+                    	</path>
+						<path>
+                		<groupId>org.projectlombok</groupId>
+                			<artifactId>lombok-mapstruct-binding</artifactId>
+                			<version>0.2.0</version>
+            			</path>
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/CimientosDelRenacimientoBackendApplication.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/CimientosDelRenacimientoBackendApplication.java
@@ -2,10 +2,9 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
+// @EnableJpaAuditing
 public class CimientosDelRenacimientoBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/common/Auditable.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/common/Auditable.java
@@ -2,16 +2,22 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.common;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PreRemove;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.user.model.UserModel;
 
 @Data
 @MappedSuperclass
@@ -26,6 +32,20 @@ public abstract class Auditable {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    // --- NUEVOS CAMPOS DE AUDITORÍA DE USUARIO ---
+    
+    @CreatedBy
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_id", updatable = false)
+    private UserModel createdBy;
+
+    @LastModifiedBy
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "updated_by_id")
+    private UserModel updatedBy;
+
+    // --------------------------------------------
 
     @Column(name = "deleted", nullable = false)
     private boolean deleted = false;

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/PersistenceConfig.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/PersistenceConfig.java
@@ -1,0 +1,68 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.config;
+
+import java.util.Optional;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.user.model.UserModel;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
+public class PersistenceConfig {
+
+    private final ApplicationContext context;
+
+    // Inyectamos el ApplicationContext en lugar del repositorio directamente
+    public PersistenceConfig(ApplicationContext context) {
+        this.context = context;
+    }
+
+    //@Bean
+    //public AuditorAware<UserModel> auditorProvider() {
+    //    return () -> {
+    //        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    //    
+    //        if (authentication == null || !authentication.isAuthenticated() || 
+    //            authentication instanceof AnonymousAuthenticationToken) {
+    //            return Optional.empty();
+    //        }
+    //    
+    //        // Si tu JwtAuthorizationFilter guarda al usuario como objeto:
+    //        if (authentication.getPrincipal() instanceof UserModel) {
+    //            return Optional.of((UserModel) authentication.getPrincipal());
+    //        }
+    //    
+    //        // Si lo guarda como String (email), lo buscamos una sola vez de forma perezosa
+    //        String email = (String) authentication.getPrincipal();
+    //        return context.getBean(UserRespository.class).findByEmail(email);
+    //        //try {
+    //        //    return context.getBean(UserRespository.class).findByEmail(email);
+    //        //} catch (Exception e) {
+    //        //    return Optional.empty(); // Evita que el error rompa la petición
+    //        //}
+    //    };
+    //}
+
+    @Bean
+    public AuditorAware<UserModel> auditorProvider() {
+        return () -> {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        
+            if (authentication == null || !authentication.isAuthenticated() || 
+                authentication instanceof AnonymousAuthenticationToken) {
+                return Optional.empty();
+            }
+        
+            return Optional.empty(); 
+        };
+    }
+
+}
+

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/SecurityConfig.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/SecurityConfig.java
@@ -53,6 +53,9 @@ public class SecurityConfig {
 
                 // Permitir acceso con un JWT valido a las rutas de usuarios
                 .requestMatchers("/api/v1/user/**").authenticated()
+
+                // Permitir acceso con un JWT valido a las rutas de obras
+                .requestMatchers("/api/v1/obra/**").authenticated()
                 
                 // Requerir autenticación para cualquier otra solicitud
                 .anyRequest().authenticated()

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/exception/GlobalExceptionHandler.java
@@ -1,10 +1,15 @@
 package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.exception;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -106,5 +111,54 @@ public class GlobalExceptionHandler {
                 request.getRequestURI()
         );
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    // 400 - MethodArgumentNotValidException
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationExceptions( MethodArgumentNotValidException ex, HttpServletRequest request){
+        
+        Map<String, String> errors = new HashMap<>();
+
+        // Extraemos cada error de campo y su mensaje personalizado
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        // Construimos el cuerpo de la respuesta con los detalles de los errores
+        Map<String, Object> response = new HashMap<>();
+        response.put("timestamp", dateTimeFormater.formatDateTime(LocalDateTime.now()));
+        response.put("status", HttpStatus.BAD_REQUEST.value());
+        response.put("error", "Validation Error");
+        response.put("message", "Los datos proporcionados no son válidos.");
+        response.put("path", request.getRequestURI());
+        response.put("errors", errors); // Detalles de los errores de validación
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // Captura errores de formato JSON (como enviar letras en campos numéricos)
+    // 400 - Bad Request
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpServletRequest request) {
+
+        String errorMessage = "Error en el formato del JSON: Verifique que los campos numéricos (investment, progress, latitude, longitude) no contengan texto.";
+
+        // Si quieres ser más específico, puedes inspeccionar la causa:
+        if (ex.getCause() instanceof com.fasterxml.jackson.databind.exc.InvalidFormatException) {
+            com.fasterxml.jackson.databind.exc.InvalidFormatException ife = (com.fasterxml.jackson.databind.exc.InvalidFormatException) ex.getCause();
+            errorMessage = "El campo '" + ife.getPath().get(0).getFieldName() + "' debe ser de tipo numérico.";
+        }
+
+        ErrorResponse error = new ErrorResponse(
+                dateTimeFormater.formatDateTime(LocalDateTime.now()),
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                errorMessage,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 }

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/controller/ObraController.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/controller/ObraController.java
@@ -1,0 +1,67 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.controller;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraMapaDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraRequestDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraResponseDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.service.IObraService;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+
+
+@RestController
+@RequestMapping("/api/v1/obra")
+@RequiredArgsConstructor
+public class ObraController {
+
+    private final IObraService obraService;
+
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @GetMapping("/mapa")
+    public ResponseEntity<List<ObraMapaDTO>> getAllForMap() {
+        return ResponseEntity.ok(obraService.findAllForObraMapa());
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @GetMapping("detail/{id}")
+    public ResponseEntity<ObraResponseDTO> getById(@PathVariable Long id) {
+        return ResponseEntity.ok(obraService.findById(id));
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PostMapping("/create")
+    public ResponseEntity<ObraResponseDTO> create(@Valid @RequestBody ObraRequestDTO request) {
+        return new ResponseEntity<>(obraService.create(request), HttpStatus.CREATED);
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PutMapping("/update/{id}")
+    public ResponseEntity<ObraResponseDTO> update(@PathVariable Long id, @Valid @RequestBody ObraRequestDTO request) {
+        return ResponseEntity.ok(obraService.update(id, request));
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
+        obraService.delete(id);
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "Obra con id " + id + " eliminada exitosamente.");
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraImageDTO.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraImageDTO.java
@@ -1,0 +1,13 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto;
+
+import lombok.Data;
+
+@Data
+public class ObraImageDTO {
+    private Long id;
+    private String url;
+    private String thumbUrl;
+    private String mimeType;
+    private String size;
+    private Integer position;
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraMapaDTO.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraMapaDTO.java
@@ -1,0 +1,13 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto;
+
+import lombok.Data;
+
+@Data
+public class ObraMapaDTO {
+
+    private Long id;
+    private String name;
+    private Double latitude;
+    private Double longitude;
+    private String municipality;
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraRequestDTO.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraRequestDTO.java
@@ -1,0 +1,51 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model.EstadoObraEnum;
+
+@Data
+public class ObraRequestDTO {
+
+    @NotBlank(message = "El nombre es obligatorio")
+    private String name;
+
+    @NotBlank(message = "El municipio es obligatorio")
+    private String municipality;
+
+    @NotBlank(message = "La ejecutora es obligatoria")
+    private String agency;
+
+    @PositiveOrZero(message = "La inversión no puede ser negativa")
+    private BigDecimal investment;
+
+    @Min(value = 0, message = "El avance debe ser al menos 0") 
+    @Max(value = 100, message = "El avance no puede ser mayor a 100")
+    private Integer progress;
+
+    private String description;
+
+    @NotNull(message = "La latitud es obligatoria")
+    @Min(value = -90, message = "Latitud inválida")
+    @Max(value = 90, message = "Latitud inválida")
+    private Double latitude;
+
+    @NotNull(message = "La longitud es obligatoria")
+    @Min(value = -180, message = "Longitud inválida")
+    @Max(value = 180, message = "Longitud inválida")    
+    private Double longitude;
+
+    @NotNull(message = "El estado de la obra es obligatorio")
+    private EstadoObraEnum status;
+
+    @Size(max = 10, message = "No se pueden subir más de 10 imágenes")
+    private List<String> imagesUrls; // Lista de URL que devuelve Cloudflare
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraResponseDTO.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraResponseDTO.java
@@ -1,0 +1,25 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class ObraResponseDTO {
+    private Long id;
+    private String name;
+    private String municipality;
+    private String agency;
+    private BigDecimal investment;
+    private Integer progress;
+    private String description;
+    private Double latitude;
+    private Double longitude;
+    private String status;
+    private List<ObraImageDTO> images;
+    private LocalDateTime createdAt;
+    private String createdBy;
+
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/mapper/ObraMapper.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/mapper/ObraMapper.java
@@ -1,0 +1,56 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraImageDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraMapaDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraRequestDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraResponseDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model.ObraImageModel;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model.ObraModel;
+
+// Con este decorador se indica que es un mapper de MapStruct y cuando se genera la clase que implementa esta interfaz, se registre como un @component de Spring.
+// Gracias a esto se puede inyectar directamente en los controladores o servicios.
+@Mapper(componentModel = "spring")
+public interface ObraMapper {
+
+    // -- ENTIDAD A MAPA DTO (Optimizado) -- //
+    ObraMapaDTO toObraMapaDTO(ObraModel obra);
+    List<ObraMapaDTO> toObraMapaDTOList(List<ObraModel> obras);
+
+    // -- ENTIDAD A OBRA RESPONSE DTO -- //
+    @Mapping(source = "createdBy.email", target = "createdBy") // Extrae el email del UserModel de Auditable
+    @Mapping(source = "status", target = "status") // Convierte el enum a String automáticamente
+    ObraResponseDTO toObraResponseDTO(ObraModel obra);
+
+    // -- OBRA REQUEST DTO A ENTIDAD -- //
+    // MapStruct usa un metodo calificador @Named("mapUrlsToImages") para resolver la anbigüedades cuando MapStruct no sabe cómo automaticamente mapear o convertir un tipo de dato a otro (por ejemplo, List<String> a List<ObraImageModel>.)
+    @Mapping(target = "id", ignore = true) // Ignorar el ID al mapear desde el request
+    @Mapping(target = "createdAt", ignore = true) 
+    @Mapping(target = "createdBy", ignore = true) 
+    @Mapping(target = "deleted", ignore = true) 
+    @Mapping(target = "deletedAt", ignore = true) 
+    @Mapping(target = "updatedAt", ignore = true) 
+    @Mapping(target = "updatedBy", ignore = true) 
+    @Mapping(target = "images", source = "imagesUrls", qualifiedByName = "mapUrlsToImages") // Con qualifiedByName MapStruct busca en el mismo archivo un metodod que tenga la anotacion @Named("mapUrlsToImages")
+    ObraModel toObraModel(ObraRequestDTO obraRequestDTO);
+
+    // -- ENTIDAD A IMAGEN DTO -- //
+    ObraImageDTO toObraImageDTO(ObraImageModel image);
+
+    // Logica personalizada para convertir String URLs a ObraImageModel
+    @Named("mapUrlsToImages")
+    default List<ObraImageModel> mapUrlsToImages(List<String> urls) {
+        if (urls == null) return null;
+        return urls.stream().map( url -> {
+            ObraImageModel img = new ObraImageModel();
+            img.setUrl(url);
+            return img;
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/EstadoObraEnum.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/EstadoObraEnum.java
@@ -1,0 +1,14 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model;
+
+public enum EstadoObraEnum {
+    PLANEACION,
+    EN_PROCESO,
+    FINALIZADA,
+    CANCELADA,
+    SUSPENDIDA,
+    NO_INICIADA,
+    INICIADA,
+    CERRADA,
+    DETENIDA
+
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/ObraImageModel.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/ObraImageModel.java
@@ -1,0 +1,52 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model;
+import org.hibernate.annotations.SQLRestriction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.common.Auditable;
+
+@Entity
+@Data
+@Table(name = "obra_images")
+@SQLRestriction("deleted = false")   
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true) // Importante para clases que heredan de otras
+public class ObraImageModel extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false)   
+    private String url;
+
+    private String providerId;
+    
+    private String thumbUrl;
+    
+    private String mimeType;
+    
+    private String size;
+    
+    private Integer position;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "obra_id", nullable = false)
+    @ToString.Exclude // <--- EVITA QUE EL TOSTRING DE OBRAIMAGE LLAME AL DE OBRA, ROMPE EL BLUCLE TOSTRING
+    @EqualsAndHashCode.Exclude // <--- EVITA QUE EL EQUALS DE OBRAIMAGE LLAME AL DE OBRA, ROMPE EL BLUCLE EQUALS
+    private ObraModel obra;
+
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/ObraModel.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/ObraModel.java
@@ -1,0 +1,81 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.SQLRestriction;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.common.Auditable;
+
+@Entity
+@Data
+@Table(name = "obras")
+@SQLRestriction("deleted = false")
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+
+public class ObraModel extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String municipality;
+
+    @Column(nullable = false)
+    private String agency;
+    
+    private BigDecimal investment;
+
+    private Integer progress;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EstadoObraEnum status;
+
+    @OneToMany(mappedBy = "obra", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude // <--- EVITA QUE EL TOSTRING DE OBRA LLAME AL DE LAS IMÁGENES
+    private List<ObraImageModel> images = new ArrayList<>();
+
+    // Método helper para sincronizar la relación bidireccional
+    public void addImage(ObraImageModel image){
+
+        if(this.images.size() >= 10){
+            throw new IllegalStateException("No se pueden agregar más de 10 imágenes a una obra.");
+        }
+
+        images.add(image); // Agrega la imagen a la lista de imágenes de la obra
+        image.setObra(this); // Le dice a la imagen : "Yo (this) soy tu obra"
+    }
+
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/repository/ObraRespository.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/repository/ObraRespository.java
@@ -1,0 +1,27 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model.ObraModel;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.repository.projections.ObraMapaProjection;
+
+public interface ObraRespository extends JpaRepository<ObraModel, Long> {
+
+    // Verificar si existe una obra con el nombre dado, incluyendo las eliminadas por soft delete
+    @Query(value = "SELECT * FROM obras WHERE name = ?1", nativeQuery = true)
+    Optional<ObraModel> findAnyByNombre(String name);
+
+    // Consulta para optimizar el mapa
+   @Query("SELECT o.id as id, o.name as name, o.latitude as latitude, " +
+       "o.longitude as longitude, o.municipality as municipality " +
+       "FROM ObraModel o") 
+    List<ObraMapaProjection> findAllForMap();
+
+    // Consulta para el detalle: Carga optimizada de imagnes (evitando N+1)
+    @Query("SELECT o FROM ObraModel o LEFT JOIN FETCH o.images WHERE o.id = ?1")
+    Optional<ObraModel> findByIdWithImages(Long id);
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/repository/projections/ObraMapaProjection.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/repository/projections/ObraMapaProjection.java
@@ -1,0 +1,10 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.repository.projections;
+
+public interface ObraMapaProjection {
+
+    Long getId();
+    String getName();
+    Double getLatitude();
+    Double getLongitude();
+    String getMunicipality();
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/IObraService.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/IObraService.java
@@ -1,0 +1,25 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.service;
+
+import java.util.List;
+
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraMapaDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraRequestDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraResponseDTO;
+
+public interface IObraService {
+
+    // Para crear una nueva obra
+    ObraResponseDTO create(ObraRequestDTO request);
+
+    // Para obtener todas las obras en formato mapa con datos optimizados
+    List<ObraMapaDTO> findAllForObraMapa();
+
+    // Para obtener una obra por su ID
+    ObraResponseDTO findById(Long id);
+
+    // Para actualizar una obra existente
+    ObraResponseDTO update(Long id, ObraRequestDTO request);
+
+    // Para eliminar una obra por su ID
+    void delete(Long id);
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/ObraServiceImpl.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/ObraServiceImpl.java
@@ -1,0 +1,174 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.exception.ConflictException;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.exception.ResourceNotFoundException;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraMapaDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraRequestDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraResponseDTO;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.mapper.ObraMapper;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model.ObraImageModel;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model.ObraModel;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.repository.ObraRespository;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.repository.projections.ObraMapaProjection;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ObraServiceImpl implements IObraService {
+
+    private final ObraRespository obraRespository;
+    private final ObraMapper obraMapper;
+    @Override
+    public ObraResponseDTO create(ObraRequestDTO request) {
+       
+        // Validar si la obra ya existe por nombre
+
+        obraRespository.findAnyByNombre(request.getName()).ifPresent(o -> {
+            throw new ConflictException("Ya existe una obra con el nombre: " + request.getName());
+        });
+
+        // Mapear el request a la entidad
+        // Gracias al @Named del mapper, aquí ya tenemos la lista de ObraImageModel
+        ObraModel obra = obraMapper.toObraModel(request);
+
+        // !IMPORTANTE! Establecer la relación bidireccional entre ObraModel y ObraImageModel
+        if (obra.getImages() != null) {
+
+            // Crea una copia de las imagenes que traia el objeto mapeado
+            List<ObraImageModel> images = new ArrayList<>(obra.getImages());
+            
+            // Limpiar la lista original de la entidad para evitar problemas de persistencia
+            obra.getImages().clear(); 
+            
+            // Version larga usando forEach
+            // Ejemplo: images.forEach(image -> obra.addImage(image));
+
+            // Version corta usando forEach
+            images.forEach(obra::addImage); // Volvemos a agregar las imagenes usando el método addImage que establece la relación correctamente
+        }
+
+        // Guardar la obra en la base de datos
+        ObraModel obraSaved = obraRespository.save(obra);
+        
+        return obraMapper.toObraResponseDTO(obraSaved);
+    }
+
+    @Override
+    @Transactional(readOnly = true) 
+    public List<ObraMapaDTO> findAllForObraMapa() {
+        // 1. Obtenemos las proyecciones (interfaces automáticas de JPA)
+        List<ObraMapaProjection> proyecciones = obraRespository.findAllForMap();
+
+        // 2. Convertimos la lista de Proyecciones a la lista de DTOs que espera tu controlador
+        return proyecciones.stream().map(p -> {
+            ObraMapaDTO dto = new ObraMapaDTO();
+            dto.setId(p.getId());
+            dto.setName(p.getName());
+            dto.setLatitude(p.getLatitude());
+            dto.setLongitude(p.getLongitude());
+            dto.setMunicipality(p.getMunicipality());
+            return dto;
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    public ObraResponseDTO findById(Long id) {
+        
+        // Usamos la consulta optimizada que carga las imágenes con JOIN FETCH para evitar el problema N+1 de las imágenes
+        ObraModel obra = obraRespository.findByIdWithImages(id).orElseThrow(() -> 
+            new ResourceNotFoundException("No se encontró la obra con ID: " + id)
+        );
+
+        return obraMapper.toObraResponseDTO(obra);
+
+    }
+
+    @Override
+    public ObraResponseDTO update(Long id, ObraRequestDTO request) {
+       
+        ObraModel obra = obraRespository.findByIdWithImages(id).orElseThrow( () ->
+            new ResourceNotFoundException("No se encontró la obra con ID: " + id)
+        );
+
+        // Validar si el nombre (si cambió, verificar que no este duplicado)
+        if (!obra.getName().equalsIgnoreCase(request.getName())){
+
+            obraRespository.findAnyByNombre(request.getName()).ifPresent( o -> {
+                throw new ConflictException("Ya existe una obra con el nombre: " + request.getName());
+            });
+        }
+
+        // Actualizar los campos básicos de la obra
+        obra.setName(request.getName());
+        obra.setAgency(request.getAgency());
+        obra.setMunicipality(request.getMunicipality());
+        obra.setInvestment(request.getInvestment());
+        obra.setProgress(request.getProgress());
+        obra.setDescription(request.getDescription());
+        obra.setLatitude(request.getLatitude());
+        obra.setLongitude(request.getLongitude());
+        obra.setStatus(request.getStatus());
+
+        /* Este es un ejemplo de control manual de las imagenes */
+        /*
+
+        // Sincronizar las imágenes (Logica: Reemplazo total de las imágenes)
+        // Borramos las imagenes anteriores agregamos las nuevas del DTO
+        obra.getImages().clear();
+        if(request.getImagesUrls() != null) {
+            
+        request.getImagesUrls().forEach( url -> {
+            ObraImageModel newImage = new ObraImageModel();
+            newImage.setUrl(url);
+            obra.addImage(newImage);
+        });
+    }
+
+        // Guardar los cambios en la base de datos
+        ObraModel updatedObra = obraRespository.save(obra);
+        
+        return obraMapper.toObraResponseDTO(updatedObra);
+
+        */
+
+        /* Este es un ejemplo de control automático de las imagenes */
+        // MANEJO DE IMAGENES USANDO EL MAPPER
+
+        // Delgamos la conversion de String -> ObraImageModel al mapper usando el metodo calificador @Named("mapUrlsToImages")
+        List<ObraImageModel> newImages = obraMapper.mapUrlsToImages(request.getImagesUrls());
+
+        // Borramos las imagenes anteriores
+        obra.getImages().clear();
+
+        // Agregamos las nuevas imagenes usando el metodo addImage que establece la relación bidireccional correctamente
+        if(newImages != null) {
+            newImages.forEach(obra::addImage);
+        }
+         return obraMapper.toObraResponseDTO(obraRespository.save(obra));
+
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long id) {
+        
+        ObraModel obra = obraRespository.findById(id).orElseThrow(() ->
+             new ResourceNotFoundException("No se puede eliminar: Obra no encontrada")
+            );
+        
+        // Soft delete
+        obra.setDeleted(true);
+        obra.setDeletedAt(LocalDateTime.now());
+        
+    }
+
+}


### PR DESCRIPTION
### Resumen
Este PR agrega las funcinalidades basicas de CRUD para el modulo de obras.

### Detalle
Para poder desarrollar este modulo se realizaron las siguientes adecuaciones.
1. El @EnableJpaAuditing que se agrego en la clase principal se descarto de ahi para poder manejarlo desde una nueva clase de configuracion llamda PersistanceConfig que sera la encargada de ayudarnos en la configuracion de JPA/Hibernate especificamente para ayudarnos con la informacion que se requere en el Auditable class.
2. El Auditable class ahora cuenta con dos campos nuevos para poder saber el usuario que relizo la operacion de crear y actulizar con el objetivo de tener mas detalles.
3. Debido a la relacion entre los modelos ObraModel, ObraImageModel y UserModel se implemento la libreria mapstruc para poder manejar el mapeo entre entidades con relaciones complejas.
4. Al GlobalExceptionHandler se le agrego 2 nuevas excepciones, la primera maneja es para capturar los errores del formato json como formatos no validos y el segundo para los campos requeridos, este ultimo va ligado con los decoradores que definimos en los DTO 

### Nota
1. Con respecto al apartado Auditable de obra aun no funciona adecuadamente, no se puede saber el usuario que crea o edita un registro, este problema surge debido aun problema con la recursividad y la forma en que se obtiene la informacion del usuario que esta ejecutando la accion, por ahora se tiene que hacer un fix en el token enviando el Id del usuario o objeto completo para resolver este tema, sin emebargo esto afectara en modulo Auth y sera necesario hacer ajustes 