### PR TITLE
refactor(Auth): Enrich SecurityContext and resolve JPA auditing recursion

### DIFF
--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/Security/JwtUtils.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/Security/JwtUtils.java
@@ -3,7 +3,6 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.Security
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
-
 import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -24,15 +23,25 @@ public class JwtUtils {
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String generateJwtToken(String email, String role, Date expiration) {
+    public String generateJwtToken(Long userId, String email, String role, Date expiration) {
         return Jwts.builder()
             .setSubject(email)
+            .claim("userId", userId)
             .claim("role", role)
             .setIssuedAt(new Date())
             .setExpiration(expiration)
             .signWith(secretKey)
             .compact();
     }
+
+    // Metodo optimizado para extraer todo el cuerpo del token
+     public  Claims getClaimsFromToken(String token){
+        return Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+     }
 
     public Boolean validateJwtToken(String authToken) {
         try {

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/Security/details/UserPrincipal.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/Security/details/UserPrincipal.java
@@ -1,0 +1,58 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.Security.details;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * Representa la identidad del usuario autenticado en el SecurityContext.
+ * Evita cargar la entidad completa UserModel de la BD durante la auditoría.
+ */ 
+public record UserPrincipal(
+    
+    Long id,
+    String email,
+    Collection<? extends GrantedAuthority> authorities
+
+) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        
+       return null; // El token es nuestra "Contraseña" ya validada
+    }
+
+    @Override
+    public String getUsername() {
+        
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/auth/Service/AuthService.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/auth/Service/AuthService.java
@@ -43,6 +43,7 @@ public class AuthService {
         Date expiresAt = jwtUtils.generateExpirationDate();
 
         String token = jwtUtils.generateJwtToken(
+            user.getIdUser(),
             user.getEmail(),
              user.getRole().getName(), 
              expiresAt

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/JwtAuthorizationFilter.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/JwtAuthorizationFilter.java
@@ -2,6 +2,7 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.config;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,19 +12,21 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.Security.JwtUtils;
-import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.user.repository.UserRespository;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.Security.details.UserPrincipal;
 
 
 @Component
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtils jwtUtils;
-    public JwtAuthorizationFilter(JwtUtils jwtUtils, UserRespository userRespository) {
+
+    public JwtAuthorizationFilter(JwtUtils jwtUtils) {
         this.jwtUtils = jwtUtils;
     }
 
@@ -40,42 +43,48 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         String token = autHeader.substring(7);
 
-        // Token invalido o expirado
+        // 1- Validar el token JWT
         if (!jwtUtils.validateJwtToken(token)) {
-            throw new BadCredentialsException("Token inválido o expirado");
+            //throw new BadCredentialsException("Token inválido o expirado");
+            filterChain.doFilter(request, response);
+            return;
         }
         
-        //if(!jwtUtils.validateJwtToken(token)){
-        //    //throw new BadCredentialsException("Token inválido o expirado");
-        //    filterChain.doFilter(request, response);  // <— NO SE LANZA EXCEPCIÓN
-        //    return;
-        //}
+        try {
+            // 2. Extraer Claims (Obtenemos tod de una vez)
+            Claims claims = jwtUtils.getClaimsFromToken(token);
+            String email = claims.getSubject();
+            String role = claims.get("role", String.class);
+            Long userId = claims.get("userId", Long.class);
 
-        String email = jwtUtils.getEmailFromJwtToken(token);
+            if (email == null || userId == null){
+                filterChain.doFilter(request, response);
+                return;
+            }
 
-        if (email == null){
-            throw new BadCredentialsException("Token invalido");
+            // 3. Crear el UserPrincipal (nuevo objeto ligero)
+            List<GrantedAuthority> authorities = List.of( new SimpleGrantedAuthority(role));
+
+            UserPrincipal userPrincipal = new UserPrincipal( 
+                userId,
+                email, 
+                authorities
+            );
+
+            // 4. Establecer la autenticación
+            // passamos el userPrincipal como principal en lugar del email
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                userPrincipal, 
+                null, 
+                authorities
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (Exception e) {
+            // Si algo falla en el parseo (ej. UUID inválido), limpiamos el contexto
+            SecurityContextHolder.clearContext();
         }
-
-        String role = jwtUtils.getRoleFromJwtToken(token);
-
-        //UserModel user = userRespository.findByEmail(email).orElse(null);
-
-        //if (user == null || user.isDeleted()) {
-        //    filterChain.doFilter(request, response);
-        //    return;
-        //}
-
-        // Convertir permisos/roles a GrantedAuthorities
-        List<GrantedAuthority> authorities = List.of(
-            new SimpleGrantedAuthority(role)
-        );
-
-        //System.out.println("Authorities del usuario: " + authorities);
-
-        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(email, null, authorities);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/PersistenceConfig.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/PersistenceConfig.java
@@ -2,7 +2,6 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.config;
 
 import java.util.Optional;
 
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
@@ -11,44 +10,17 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.Security.details.UserPrincipal;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.user.model.UserModel;
 
 @Configuration
 @EnableJpaAuditing(auditorAwareRef = "auditorProvider")
 public class PersistenceConfig {
 
-    private final ApplicationContext context;
-
-    // Inyectamos el ApplicationContext en lugar del repositorio directamente
-    public PersistenceConfig(ApplicationContext context) {
-        this.context = context;
-    }
-
-    //@Bean
-    //public AuditorAware<UserModel> auditorProvider() {
-    //    return () -> {
-    //        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    //    
-    //        if (authentication == null || !authentication.isAuthenticated() || 
-    //            authentication instanceof AnonymousAuthenticationToken) {
-    //            return Optional.empty();
-    //        }
-    //    
-    //        // Si tu JwtAuthorizationFilter guarda al usuario como objeto:
-    //        if (authentication.getPrincipal() instanceof UserModel) {
-    //            return Optional.of((UserModel) authentication.getPrincipal());
-    //        }
-    //    
-    //        // Si lo guarda como String (email), lo buscamos una sola vez de forma perezosa
-    //        String email = (String) authentication.getPrincipal();
-    //        return context.getBean(UserRespository.class).findByEmail(email);
-    //        //try {
-    //        //    return context.getBean(UserRespository.class).findByEmail(email);
-    //        //} catch (Exception e) {
-    //        //    return Optional.empty(); // Evita que el error rompa la petición
-    //        //}
-    //    };
-    //}
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Bean
     public AuditorAware<UserModel> auditorProvider() {
@@ -59,8 +31,19 @@ public class PersistenceConfig {
                 authentication instanceof AnonymousAuthenticationToken) {
                 return Optional.empty();
             }
-        
-            return Optional.empty(); 
+
+                
+            // Recuperamos nuestro Userprincipal desde el contexto de seguridad
+            UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();  
+            
+            // Usamos getReference
+            // Esto crea un Proxy de Hinernate con el ID.
+            // No ejecuta un select en la base de datos.
+            // Al no haber un select, no se dispara el flujo de auditoría para el UserModel.
+            UserModel userModelProxy = entityManager.getReference(UserModel.class, userPrincipal.id());
+
+            return Optional.of(userModelProxy);
+
         };
     }
 

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/exception/GlobalExceptionHandler.java
@@ -8,12 +8,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import jakarta.servlet.http.HttpServletRequest;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.exception.dto.ErrorResponseDTO;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.util.DateFormatter;
 
 @ControllerAdvice
@@ -160,5 +162,17 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex, HttpServletRequest request) {
+         ErrorResponse error = new ErrorResponse(
+            dateTimeFormater.formatDateTime(LocalDateTime.now()),
+            HttpStatus.FORBIDDEN.value(),
+            "Forbidden",
+            "No tienes permisos para realizar esta acción.", 
+            request.getRequestURI()
+        );
+        return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
     }
 }

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/controller/ObraController.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/controller/ObraController.java
@@ -7,12 +7,14 @@ import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.Security.details.UserPrincipal;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraMapaDTO;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraRequestDTO;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraResponseDTO;
@@ -32,7 +34,7 @@ public class ObraController {
 
     private final IObraService obraService;
 
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_USER')")
     @GetMapping("/mapa")
     public ResponseEntity<List<ObraMapaDTO>> getAllForMap() {
         return ResponseEntity.ok(obraService.findAllForObraMapa());
@@ -46,7 +48,11 @@ public class ObraController {
 
     @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @PostMapping("/create")
-    public ResponseEntity<ObraResponseDTO> create(@Valid @RequestBody ObraRequestDTO request) {
+    public ResponseEntity<ObraResponseDTO> create(
+        @Valid @RequestBody ObraRequestDTO request,
+        @AuthenticationPrincipal UserPrincipal userPrincipal // Injectamos el usuario autenticado
+    ) {
+        System.out.println("El usuario autenticado ID: " + userPrincipal.id() + ", Email: " + userPrincipal.email() + " está creando una obra.");
         return new ResponseEntity<>(obraService.create(request), HttpStatus.CREATED);
     }
 


### PR DESCRIPTION
### Resumen
Este PR se enfoco en refactorizar el codigo en el modulo Auth para poder agregar al token el objeto del usuario y con esto poder utlizarlo en el AuditorAware evitando asi realizar consultas a la BD en el PersistenceConfig y causar problemas de recusividad provocando bucles infinitos debido a la relaciones.

### Detalle
- Se implementó UserPrincipal como un record que extiende UserDetails para almacenar el userId y las autoridades.
- Se actualizó JwtUtils para incluir el userId en los claims del JWT, eliminando consultas a la BD durante la autorización.
- Se refactorizó PersistenceConfig para usar entityManager.getReference() en el AuditorAware, resolviendo el StackOverflow y la UnexpectedRollbackException.
- Se estandarizó la autorización usando hasAnyAuthority para coincidir con las convenciones de nombres de roles en la base de datos en el modulo de obras.
- Se agregó un manejador para AccessDeniedException en el GlobalExceptionHandler para asegurar respuestas de error consistentes.