### PR TITLE
feat(obra): Implement image management with Cloudflare and complete auditing

### DIFF
--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/CimientosDelRenacimientoBackendApplication.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/CimientosDelRenacimientoBackendApplication.java
@@ -2,9 +2,13 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.config.CloudflareConfig;
 
 @SpringBootApplication
 // @EnableJpaAuditing
+@EnableConfigurationProperties(CloudflareConfig.class)
 public class CimientosDelRenacimientoBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/CloudflareConfig.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/CloudflareConfig.java
@@ -1,0 +1,16 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Data;
+
+@Configuration
+@ConfigurationProperties(prefix = "cloudflare")
+@Data
+public class CloudflareConfig {
+    private String accountId;
+    private String apiToken;
+    private String apiUrl;
+    private String deliveryUrl;
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/JwtAuthorizationFilter.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/config/JwtAuthorizationFilter.java
@@ -2,9 +2,6 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.config;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
-
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/exception/GlobalExceptionHandler.java
@@ -175,4 +175,17 @@ public class GlobalExceptionHandler {
         );
         return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
     }
+
+    // 500 - StorageException
+    @ExceptionHandler(StorageException.class)
+    public ResponseEntity<ErrorResponse> handleStorageException(StorageException ex, HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                dateTimeFormater.formatDateTime(LocalDateTime.now()),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Storage Error",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
 }

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/exception/StorageException.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/exception/StorageException.java
@@ -1,0 +1,9 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.exception;
+
+public class StorageException extends ApiException {
+
+    public StorageException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/controller/ObraController.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/controller/ObraController.java
@@ -8,9 +8,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -49,20 +50,25 @@ public class ObraController {
     @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @PostMapping("/create")
     public ResponseEntity<ObraResponseDTO> create(
-        @Valid @RequestBody ObraRequestDTO request,
+        @RequestPart @Valid ObraRequestDTO request,
+        @RequestPart(value = "files", required = false) List<MultipartFile> files,
         @AuthenticationPrincipal UserPrincipal userPrincipal // Injectamos el usuario autenticado
     ) {
         System.out.println("El usuario autenticado ID: " + userPrincipal.id() + ", Email: " + userPrincipal.email() + " está creando una obra.");
-        return new ResponseEntity<>(obraService.create(request), HttpStatus.CREATED);
+        return new ResponseEntity<>(obraService.create(request, files), HttpStatus.CREATED);
     }
 
     @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @PutMapping("/update/{id}")
-    public ResponseEntity<ObraResponseDTO> update(@PathVariable Long id, @Valid @RequestBody ObraRequestDTO request) {
-        return ResponseEntity.ok(obraService.update(id, request));
+    public ResponseEntity<ObraResponseDTO> update(
+        @PathVariable Long id, 
+        @Valid @RequestPart ObraRequestDTO request,
+        @RequestPart(value = "files", required = false) List<MultipartFile> files
+    ) {
+        return ResponseEntity.ok(obraService.update(id, request, files));
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
+     @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @DeleteMapping("/delete/{id}")
     public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
         obraService.delete(id);

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraRequestDTO.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/dto/ObraRequestDTO.java
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model.EstadoObraEnum;
 
@@ -46,6 +45,6 @@ public class ObraRequestDTO {
     @NotNull(message = "El estado de la obra es obligatorio")
     private EstadoObraEnum status;
 
-    @Size(max = 10, message = "No se pueden subir más de 10 imágenes")
-    private List<String> imagesUrls; // Lista de URL que devuelve Cloudflare
+    private List<Long> keepImageIds;
+
 }

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/mapper/ObraMapper.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/mapper/ObraMapper.java
@@ -37,7 +37,7 @@ public interface ObraMapper {
     @Mapping(target = "deletedAt", ignore = true) 
     @Mapping(target = "updatedAt", ignore = true) 
     @Mapping(target = "updatedBy", ignore = true) 
-    @Mapping(target = "images", source = "imagesUrls", qualifiedByName = "mapUrlsToImages") // Con qualifiedByName MapStruct busca en el mismo archivo un metodod que tenga la anotacion @Named("mapUrlsToImages")
+    @Mapping(target = "images", ignore = true) 
     ObraModel toObraModel(ObraRequestDTO obraRequestDTO);
 
     // -- ENTIDAD A IMAGEN DTO -- //

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/ObraImageModel.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/ObraImageModel.java
@@ -1,4 +1,5 @@
 package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import jakarta.persistence.Column;
@@ -20,6 +21,7 @@ import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.common.Au
 @Entity
 @Data
 @Table(name = "obra_images")
+@SQLDelete(sql = "UPDATE obra_images SET deleted = true, deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted = false")   
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/ObraModel.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/model/ObraModel.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import jakarta.persistence.CascadeType;
@@ -26,6 +27,7 @@ import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.common.Au
 @Entity
 @Data
 @Table(name = "obras")
+@SQLDelete(sql = "UPDATE obras SET deleted = true, deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted = false")
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/IObraService.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/IObraService.java
@@ -2,6 +2,8 @@ package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.ser
 
 import java.util.List;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraMapaDTO;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraRequestDTO;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.ObraResponseDTO;
@@ -9,7 +11,7 @@ import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.dto.
 public interface IObraService {
 
     // Para crear una nueva obra
-    ObraResponseDTO create(ObraRequestDTO request);
+    ObraResponseDTO create(ObraRequestDTO request, List<MultipartFile> files);
 
     // Para obtener todas las obras en formato mapa con datos optimizados
     List<ObraMapaDTO> findAllForObraMapa();
@@ -18,7 +20,7 @@ public interface IObraService {
     ObraResponseDTO findById(Long id);
 
     // Para actualizar una obra existente
-    ObraResponseDTO update(Long id, ObraRequestDTO request);
+    ObraResponseDTO update(Long id, ObraRequestDTO request, List<MultipartFile> files);
 
     // Para eliminar una obra por su ID
     void delete(Long id);

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/ObraServiceImpl.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/ObraServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.exception.ConflictException;
@@ -19,6 +20,8 @@ import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.mode
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.model.ObraModel;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.repository.ObraRespository;
 import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.obra.repository.projections.ObraMapaProjection;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.dto.ImageStorageResponse;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.service.IImageStorageService;
 
 @Service
 @RequiredArgsConstructor
@@ -27,36 +30,48 @@ public class ObraServiceImpl implements IObraService {
 
     private final ObraRespository obraRespository;
     private final ObraMapper obraMapper;
+    private final IImageStorageService imageStorageService;
     @Override
-    public ObraResponseDTO create(ObraRequestDTO request) {
+    public ObraResponseDTO create(ObraRequestDTO request, List<MultipartFile> files) {
        
-        // Validar si la obra ya existe por nombre
+        // 1. Validar si la obra ya existe por nombre
 
         obraRespository.findAnyByNombre(request.getName()).ifPresent(o -> {
             throw new ConflictException("Ya existe una obra con el nombre: " + request.getName());
         });
 
-        // Mapear el request a la entidad
+        // 2. Mapear el request DTO a la entidad
         // Gracias al @Named del mapper, aquí ya tenemos la lista de ObraImageModel
         ObraModel obra = obraMapper.toObraModel(request);
 
-        // !IMPORTANTE! Establecer la relación bidireccional entre ObraModel y ObraImageModel
-        if (obra.getImages() != null) {
-
-            // Crea una copia de las imagenes que traia el objeto mapeado
-            List<ObraImageModel> images = new ArrayList<>(obra.getImages());
-            
-            // Limpiar la lista original de la entidad para evitar problemas de persistencia
-            obra.getImages().clear(); 
-            
-            // Version larga usando forEach
-            // Ejemplo: images.forEach(image -> obra.addImage(image));
-
-            // Version corta usando forEach
-            images.forEach(obra::addImage); // Volvemos a agregar las imagenes usando el método addImage que establece la relación correctamente
+        // 3. Validar la cantidad de imágenes subidas
+        if (files.size() > 10) {
+            throw new IllegalArgumentException("No se pueden subir más de 10 imágenes por obra.");
         }
 
-        // Guardar la obra en la base de datos
+        // 4. Procesar y subir cada imagen usando el servicio de almacenamiento
+        if (files != null && !files.isEmpty()) {
+
+            files.forEach(file -> {
+                 // 1. Subir al proveedor
+                 ImageStorageResponse response = imageStorageService.upload(file);
+
+                 // 2. Crear modelo de imagen con los datos del proveedor
+                 ObraImageModel imgModel = new ObraImageModel();
+                 imgModel.setUrl(response.url());
+                 imgModel.setProviderId(response.providerId());
+                 imgModel.setThumbUrl(response.thumbUrl());
+                 imgModel.setMimeType(response.mimeType());
+                 imgModel.setSize(response.size());
+                 imgModel.setPosition(null);
+
+                 // 3. Agregar la imagen a la obra (establece la relación bidireccional)
+                 obra.addImage(imgModel); 
+                 
+            });
+        }
+
+        // 5. Guardar la obra en la base de datos
         ObraModel obraSaved = obraRespository.save(obra);
         
         return obraMapper.toObraResponseDTO(obraSaved);
@@ -93,13 +108,14 @@ public class ObraServiceImpl implements IObraService {
     }
 
     @Override
-    public ObraResponseDTO update(Long id, ObraRequestDTO request) {
+    public ObraResponseDTO update(Long id, ObraRequestDTO request, List<MultipartFile> newFiles) {
        
+        // 1. Obtener la obra existente
         ObraModel obra = obraRespository.findByIdWithImages(id).orElseThrow( () ->
             new ResourceNotFoundException("No se encontró la obra con ID: " + id)
         );
 
-        // Validar si el nombre (si cambió, verificar que no este duplicado)
+        // 2. Validar si el nombre (si cambió, verificar que no este duplicado)
         if (!obra.getName().equalsIgnoreCase(request.getName())){
 
             obraRespository.findAnyByNombre(request.getName()).ifPresent( o -> {
@@ -107,7 +123,7 @@ public class ObraServiceImpl implements IObraService {
             });
         }
 
-        // Actualizar los campos básicos de la obra
+        // 3. Actualizar los campos básicos de la obra
         obra.setName(request.getName());
         obra.setAgency(request.getAgency());
         obra.setMunicipality(request.getMunicipality());
@@ -118,42 +134,52 @@ public class ObraServiceImpl implements IObraService {
         obra.setLongitude(request.getLongitude());
         obra.setStatus(request.getStatus());
 
-        /* Este es un ejemplo de control manual de las imagenes */
-        /*
+        // 4. Gestion de imagenes existentes
+        List<Long> keepImageIds = request.getKeepImageIds() != null ? request.getKeepImageIds() : new ArrayList<>();
 
-        // Sincronizar las imágenes (Logica: Reemplazo total de las imágenes)
-        // Borramos las imagenes anteriores agregamos las nuevas del DTO
-        obra.getImages().clear();
-        if(request.getImagesUrls() != null) {
-            
-        request.getImagesUrls().forEach( url -> {
-            ObraImageModel newImage = new ObraImageModel();
-            newImage.setUrl(url);
-            obra.addImage(newImage);
+        // 5. Identificar cules se deben eliminar
+        List<ObraImageModel> imagesToRemove = obra.getImages().stream()
+            .filter(img -> !keepImageIds.contains(img.getId()))
+            .collect(Collectors.toList());
+
+        // 6. Eliminar las imagenes
+        imagesToRemove.forEach(img -> {
+            // Borrado fisico en el proveedor
+            try {
+                imageStorageService.delete(img.getProviderId());
+            } catch (Exception e) {
+                // Loguear el error pero continuar con la eliminación si es critico mantener la coherencia
+                System.err.println("Error al eliminar la imagen en storage: " + img.getProviderId() + " - " + e.getMessage());
+            }
+            // Eliminar de la colección de la obra
+            obra.getImages().remove(img); 
         });
-    }
 
-        // Guardar los cambios en la base de datos
-        ObraModel updatedObra = obraRespository.save(obra);
-        
-        return obraMapper.toObraResponseDTO(updatedObra);
+        // 7. Procesar las nuevas imagenes a agregar
+        if (newFiles != null && !newFiles.isEmpty()) {
+             
+            // Validar la cantidad total de imagenes despues de agregar las nuevas
+            if (obra.getImages().size() + newFiles.size() > 10){
+                throw new IllegalStateException("No se pueden agregar más de 10 imágenes a una obra.");
+            }
 
-        */
+            newFiles.forEach(file -> {
+                
+                ImageStorageResponse response = imageStorageService.upload(file);
+                ObraImageModel imgModel = new ObraImageModel();
 
-        /* Este es un ejemplo de control automático de las imagenes */
-        // MANEJO DE IMAGENES USANDO EL MAPPER
+                imgModel.setUrl(response.url());
+                imgModel.setProviderId(response.providerId());
+                imgModel.setThumbUrl(response.thumbUrl());
+                imgModel.setMimeType(response.mimeType());
+                imgModel.setSize(response.size());
+                imgModel.setPosition(null);
 
-        // Delgamos la conversion de String -> ObraImageModel al mapper usando el metodo calificador @Named("mapUrlsToImages")
-        List<ObraImageModel> newImages = obraMapper.mapUrlsToImages(request.getImagesUrls());
-
-        // Borramos las imagenes anteriores
-        obra.getImages().clear();
-
-        // Agregamos las nuevas imagenes usando el metodo addImage que establece la relación bidireccional correctamente
-        if(newImages != null) {
-            newImages.forEach(obra::addImage);
+                obra.addImage(imgModel);
+            });
         }
-         return obraMapper.toObraResponseDTO(obraRespository.save(obra));
+       
+        return obraMapper.toObraResponseDTO(obraRespository.save(obra));
 
     }
 
@@ -161,14 +187,56 @@ public class ObraServiceImpl implements IObraService {
     @Transactional
     public void delete(Long id) {
         
+        // 1.- Obtener la obra con sus imágenes para poder eliminarlas también
         ObraModel obra = obraRespository.findById(id).orElseThrow(() ->
              new ResourceNotFoundException("No se puede eliminar: Obra no encontrada")
             );
         
         // Soft delete
+        /*
+            1. Marcar la obra como borrada para que JPA Auditing detecte 
+            el cambio en la entidad y llene 'updated_at' y 'deleted_by'
+        */ 
         obra.setDeleted(true);
         obra.setDeletedAt(LocalDateTime.now());
+
+        // 2. Al guardar, JPA Auditing pondra al usuario actual en 'updated_by'
+        //obraRespository.save(obra);
+
+        /*
+            3. Las imagenes tambien se mantienen con el 'updated_by' y 'deleted_at' 
+            del que borra la obra, hay que recorrerlas y marcarlas como borradas
+        */
+        obra.getImages().forEach(img -> {
+            img.setDeleted(true);
+            img.setDeletedAt(LocalDateTime.now());
+
+            // Intentar borrar en Cloudflare mientras recorremos las imágenes, así evitamos tener que hacer un segundo recorrido solo para eso
+            //try {
+            //    imageStorageService.delete(img.getProviderId());
+            //} catch (Exception e) {
+            //    // Loguear el error pero continuar con la eliminación si es critico mantener la coherencia
+            //    System.err.println("Error al eliminar la imagen en storage: " + img.getProviderId() + " - " + e.getMessage());
+            //}
+        });
+
+        // 4. ¡PASO CLAVE!: Sincronizar cambios de auditoría
+        // Esto obliga a JPA a ejecutar los UPDATES de auditoría (updated_by) AHORA.
+        obraRespository.saveAndFlush(obra);
         
+        // 5. Ejecutar el Soft Delete final
+        // Ahora que la auditoría ya se guardó, procedemos al borrado lógico
+        /* Nota: Al ejecutar el delete de la obra automaticamente se marca deleted = true 
+            no se elimina fisicamente de la base de datos gracias a la anotación @SQLDelete
+            en la entidad ObraModel y las imagnes se marcan como deleted = true pero no se puede 
+            tener una audtioria para saber quien hizo ese cambio en el estado de las imagenes.
+        */
+        obraRespository.delete(obra);
+    
+        // Al ejecutar delete(obra):
+        // - Se dispara el SQL de @SQLDelete de la Obra.
+        // - Se dispara el SQL de @SQLDelete de cada Imagen (por el Cascade).
+        //   siempre y cuando el contexto de seguridad tenga al usuario.
     }
 
 }

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/dto/CloudflareResponse.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/dto/CloudflareResponse.java
@@ -1,0 +1,18 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.dto;
+
+import java.util.List;
+
+public record CloudflareResponse(
+    Result result,
+    boolean success,
+    List<Object> errors,
+    List<Object> messages
+) {
+    public record Result(
+        String id,
+        String filename,
+        String uploaded,
+        boolean requireSignedURLs,
+        List<String> variants
+    ){}
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/dto/ImageStorageResponse.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/dto/ImageStorageResponse.java
@@ -1,0 +1,9 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.dto;
+
+public record ImageStorageResponse(
+    String url,
+    String providerId,
+    String thumbUrl,
+    String mimeType,
+    String size
+) {}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/service/CloudflareStorageServiceImp.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/service/CloudflareStorageServiceImp.java
@@ -1,0 +1,110 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.multipart.MultipartFile;
+
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.config.CloudflareConfig;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.exception.StorageException;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.dto.CloudflareResponse;
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.dto.ImageStorageResponse;
+
+@Service
+@ConditionalOnProperty(name = "storage.provider", havingValue = "cloudflare")
+public class CloudflareStorageServiceImp implements IImageStorageService{
+
+    private final CloudflareConfig cloudflareConfig;
+    private final RestClient restClient;
+
+    public CloudflareStorageServiceImp(CloudflareConfig cloudflareConfig, RestClient.Builder builder) {
+
+        this.cloudflareConfig = cloudflareConfig;
+        this.restClient = builder.build();
+    }
+
+    @Override
+    public ImageStorageResponse upload(MultipartFile file) {
+
+        try {
+            
+            // Cloudflare requiere un MultipartBody
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", file.getResource());
+
+            CloudflareResponse response = restClient.post()
+                .uri(cloudflareConfig.getApiUrl() + cloudflareConfig.getAccountId() + "/images/v1")
+                .header("Authorization", "Bearer " + cloudflareConfig.getApiToken())
+                .body(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) ->{
+                    throw new StorageException("El servicio de almacenamiento externo no respondió correctamente.");
+                })
+                .body(CloudflareResponse.class);
+
+            if (response == null || !response.success()){ 
+                throw new StorageException("Cloudflare no pudo procesar la imagen correctamente.");
+            }    
+            
+            if ( response != null && response.success()){
+                // Buscamos las URLs en la lista de variantes
+                String publicUrl = response.result().variants().stream()
+                    .filter(url -> url.contains("/public/"))
+                    .findFirst()
+                    .orElse(response.result().variants().get(0  ));
+                
+                String thumbUrl = response.result().variants().stream()
+                    .filter(url -> url.contains("/thumbnail/"))
+                    .findFirst()
+                    .orElse(publicUrl);
+
+                return new ImageStorageResponse(
+                    publicUrl, 
+                    response.result().id(), 
+                    thumbUrl, 
+                    file.getContentType(),
+                    String.valueOf(file.getSize())
+                );
+            }
+
+            //throw new RuntimeException("Resouesta de Cloudflare no exitosa");
+            //return mapResponse(response, file);
+            throw new StorageException("No se pudo procesar la imagen.");
+
+        }
+        catch(StorageException e){
+            throw e; // Re-lanzamos la excepción de almacenamiento
+        
+        } catch (Exception e) {
+            throw new StorageException("Ocurrió un error inesperado al procesar la imagen: " + e.getMessage());
+        } 
+        
+    }
+
+    @Override
+    public void delete(String providerId) {
+        try {
+            restClient.delete()
+            .uri(cloudflareConfig.getApiUrl() + cloudflareConfig.getAccountId() + "/images/v1/" + providerId)
+            .header("Authorization", "Bearer " + cloudflareConfig.getApiToken())
+            .retrieve()
+            .onStatus(status -> status.equals(HttpStatus.NOT_FOUND), (req, res) -> {
+                // Si la imagen no existe, no hacemos nada
+                throw new StorageException("La imagen no existe en el servicio de almacenamiento externo cloudflare.");
+            })
+            .onStatus(HttpStatusCode::isError, (req, res) ->{
+                throw new StorageException("Error al eliminar la imagen en el servicio de almacenamiento externo cloudflare.");  
+            })
+            .toBodilessEntity();
+        } catch (Exception e) {
+            System.err.println("No se pudo eliminar físicamente en Cloudflare: " + providerId);
+        }
+    }
+
+
+
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/service/IImageStorageService.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/service/IImageStorageService.java
@@ -1,0 +1,14 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.dto.ImageStorageResponse;
+
+
+public interface IImageStorageService {
+
+    ImageStorageResponse upload(MultipartFile file);
+
+    void delete(String providerId);
+
+}

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/service/LocalStorageServiceImpl.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/service/LocalStorageServiceImpl.java
@@ -1,0 +1,25 @@
+package mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import mx.gob.cimientosdelrenacimiento.CimientosDelRenacimientoBackend.storage.dto.ImageStorageResponse;
+
+@Service
+@ConditionalOnProperty(name = "storage.provider", havingValue = "local")
+public class LocalStorageServiceImpl implements IImageStorageService {
+
+    @Override
+    public ImageStorageResponse upload(MultipartFile file) {
+        
+        return new ImageStorageResponse("url", "providerId", "thumbUrl", "mimeType", "size");
+    }
+
+    @Override
+    public void delete(String fileName) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,18 @@ spring.jpa.properties.hibernate.format_sql=true
 # 🪵 LOGGING (nivel base)
 # =========================================================
 logging.level.root=INFO
+
+# =========================================================
+# ☁️ STORAGE PROVIDER
+# Indica el proveedor de almacenamiento de imágenes
+# (cloudflare, aws, local, etc.)
+# =========================================================
+storage.provider=${STORAGE_PROVIDER} 
+
+# =========================================================
+# ☁️ CLOUDFLARE IMAGE STORAGE CONFIGURATION
+# =========================================================
+cloudflare.account-id=${CLOUDFLARE_ACCOUNT_ID}
+cloudflare.api-token=${CLOUDFLARE_API_TOKEN}
+cloudflare.api-url=https://api.cloudflare.com/client/v4/accounts/
+cloudflare.delivery-url=https://imagedelivery.net/


### PR DESCRIPTION
Este PR se enfoca en en conectar el servicios de almacenamiento remoto de imágenes de Cloudflare al momento de crear, editar y eliminar una obra.

Cuando el usuario crea, edita o elimina una obra con imágenes estas son también gestionadas en Cloudflare.

- Integración de Cloudflare Images para almacenamiento físico (Hard Delete/Upload).
- Unicamente en Cloudflare se aplica el Hard delete para optimizar el espacio de almacenamiento pero en la base de datos se mantiene el registro.
- Implementación de lógica diferencial en el update para sincronizar imágenes (keep/remove/add).
- Configuración de Soft Delete dinámico en Obra y ObraImage mediante @SQLDelete y @SQLRestriction.
- Garantizada la auditoría de usuario (updated_by) en procesos de eliminación mediante sincronización de contexto (flush).
- Corrección de metadatos de imagen (MimeType y Size) en el flujo de persistencia.
- Refactor del ObraController para soporte de Multipart/form-data con DTO JSON.