### PR TITLE
refactor(Storage): Apply refactoring on the delete method of the storage service

### DIFF
--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/ObraServiceImpl.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/obra/service/ObraServiceImpl.java
@@ -160,7 +160,8 @@ public class ObraServiceImpl implements IObraService {
                 imageStorageService.delete(img.getProviderId());
             } catch (Exception e) {
                 // Loguear el error pero continuar con la eliminación si es critico mantener la coherencia
-                System.err.println("Error al eliminar la imagen en storage: " + img.getProviderId() + " - " + e.getMessage());
+                // Si Cloudflare falla por red o API, solo avisamos en consola
+                System.err.println("Inconsistencia: No se borró en la nube, pero se quitará de la DB: " + img.getProviderId() + " - " + e.getMessage());
             }
             // Eliminar de la colección de la obra
             obra.getImages().remove(img); 

--- a/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/service/CloudflareStorageServiceImp.java
+++ b/src/main/java/mx/gob/cimientosdelrenacimiento/CimientosDelRenacimientoBackend/storage/service/CloudflareStorageServiceImp.java
@@ -93,11 +93,18 @@ public class CloudflareStorageServiceImp implements IImageStorageService{
             .header("Authorization", "Bearer " + cloudflareConfig.getApiToken())
             .retrieve()
             .onStatus(status -> status.equals(HttpStatus.NOT_FOUND), (req, res) -> {
-                // Si la imagen no existe, no hacemos nada
-                throw new StorageException("La imagen no existe en el servicio de almacenamiento externo cloudflare.");
+                /*
+                Esto excepcion rompe con la arquitectura de software (Clean code + solid),ya que no hace que sea un metodo resiliente y 
+                tenga una responsavilidad unica por lo que devuelve fragil la arquitectura de software.
+                 */
+                //throw new StorageException("La imagen no existe en el servicio de almacenamiento externo cloudflare.");
+                
+                //LOGICA CLEAN: Si no existe, imprimimos un aviso, pero no lanzamos una excepción.
+                // El objetivo de borrar se considera "exitoso" porque ya no está
+                System.out.println("Aviso: la imagen " + providerId + " ya no existe en el servicio de almacenamiento externo.");
             })
             .onStatus(HttpStatusCode::isError, (req, res) ->{
-                throw new StorageException("Error al eliminar la imagen en el servicio de almacenamiento externo cloudflare.");  
+                throw new StorageException("Error de comunicación con el servicio de almacenamiento externo al intentar borrar la imagen.");  
             })
             .toBodilessEntity();
         } catch (Exception e) {


### PR DESCRIPTION
En este PR simplemente se realizan la refactorización del metodo delete en el servicio de almacenamiento, ya que esto rompía con los principios de clean code + solid: cuando había una excepción "No se podía eliminar la imagen del servicio de almacenamiento externo"  esto detiene el proceso de edición. 

Si la imagen ya no existe en Cloudflare, el objetivo del usuario ya se cumplió. Bloquear la actualización de la obra por un error de un tercero (Cloudflare) es un antipatrón.

Ahora Si la imagen desapareció de Cloudflare antes de que le diéramos "borrar" (por ejemplo, alguien la borró desde el panel de Cloudflare), la aplicación sigue funcionando.